### PR TITLE
fix typo in readme.md code example

### DIFF
--- a/readme.js
+++ b/readme.js
@@ -16,10 +16,10 @@
  *
  *     const source = fromObs(Rx.Observable.interval(1000).take(4));
  *
- *     observe(x => console.log(x)(source); // 0
- *                                          // 1
- *                                          // 2
- *                                          // 3
+ *     observe(x => console.log(x))(source); // 0
+ *                                           // 1
+ *                                           // 2
+ *                                           // 3
  *
  * Convert anything that has the `.subscribe` method:
  *


### PR DESCRIPTION
This pull request adds a missing parenthesis to the example code.

Please let me know if there is anything I need to change.